### PR TITLE
Read in build.properties

### DIFF
--- a/libexec/sbtenv-version-file
+++ b/libexec/sbtenv-version-file
@@ -15,8 +15,17 @@ find_local_version_file() {
   done
 }
 
+find_project_build_properties() {
+  if [ -r "${PWD}/project/build.properties" ]; then
+    echo "${PWD}/project/build.properties"
+    exit
+  fi
+}
+
 find_local_version_file "${SBTENV_DIR}"
 [ "${SBTENV_DIR}" = "${PWD}" ] || find_local_version_file "${PWD}"
+
+find_project_build_properties
 
 global_version_file="${SBTENV_ROOT}/version"
 

--- a/libexec/sbtenv-version-file-read
+++ b/libexec/sbtenv-version-file-read
@@ -7,10 +7,18 @@ test -n "${SBTENV_DEBUG}" && set -x
 VERSION_FILE="${1}"
 
 if [ -e "${VERSION_FILE}" ]; then
-  # Read the first non-whitespace word from the specified version file.
-  # Be careful not to load it whole in case there's something crazy in it.
-  words=($(cut -b 1-1024 "${VERSION_FILE}"))
-  version="${words[0]}"
+
+  case "${VERSION_FILE}" in
+    *build.properties)
+      words=($(cut -d = -f 2 "${VERSION_FILE}"))
+      version="sbt-${words[0]}"
+      ;;
+    *)
+      # Read the first non-whitespace word from the specified version file.
+      # Be careful not to load it whole in case there's something crazy in it.
+      words=($(cut -b 1-1024 "${VERSION_FILE}"))
+      version="${words[0]}"
+  esac
 
   if [ -n "${version}" ]; then
     echo "${version}"


### PR DESCRIPTION
I have challenged the #9 task.
Tentatively, read build.properties at only project root directory.

I'm sorry but I'm not good at ShellScript,
so I hope you feel free to point out the bad points or reject it.

Current restriction ( or bug),
there are multiple lines settings in build.properties and
sbt.version's setting at second line or later,
version read will fail.
