### PR TITLE
Add sbt 1.0 support

### DIFF
--- a/libexec/sbtenv
+++ b/libexec/sbtenv
@@ -21,7 +21,7 @@ fi
 
 READLINK=$(type -p greadlink readlink | head -1)
 if [ -z "${READLINK}" ]; then
-  echo "sbtenv: connot find readlink - are you missing GNU coreutils?" >& 2
+  echo "sbtenv: cannot find readlink - are you missing GNU coreutils?" >& 2
   exit 1
 fi
 
@@ -56,7 +56,7 @@ if [ -z "${SBTENV_DIR}" ]; then
   SBTENV_DIR="$(pwd)"
 else
   cd "${SBTENV_DIR}" 2> /dev/null || {
-    echo "sbtenv: connot change working directory to \"${SBTENV_DIR}\""
+    echo "sbtenv: cannot change working directory to \"${SBTENV_DIR}\""
     exit 1
   } >& 2
   SBTENV_DIR="$(pwd)"

--- a/libexec/sbtenv-init
+++ b/libexec/sbtenv-init
@@ -28,7 +28,7 @@ fi
 
 READLINK=$(type -p greadlink readlink | head -1)
 if [ -z "${READLINK}" ]; then
-  echo "sbtenv: connot find readlink - are you missing GNU coreutils?" >& 2
+  echo "sbtenv: cannot find readlink - are you missing GNU coreutils?" >& 2
   exit 1
 fi
 

--- a/plugins/sbt-install/bin/sbtenv-install
+++ b/plugins/sbt-install/bin/sbtenv-install
@@ -10,7 +10,7 @@ fi
 
 READLINK=$(type -p greadlink readlink | head -1)
 if [ -z "${READLINK}" ]; then
-  echo "sbt-install: connot find readlink - are you missing GNU coreutils?" >& 2
+  echo "sbt-install: cannot find readlink - are you missing GNU coreutils?" >& 2
   exit 1
 fi
 
@@ -34,7 +34,7 @@ abs_dirname() {
 
 SHA1SUM=$(type -p sha1sum shasum | head -1)
 if [ -z "${SHA1SUM}" ]; then
-  echo "sbt-install: connot find sha1sum - are you missing GNU coreutils?" >& 2
+  echo "sbt-install: cannot find sha1sum - are you missing GNU coreutils?" >& 2
   exit 1
 fi
 

--- a/plugins/sbt-install/bin/sbtenv-install
+++ b/plugins/sbt-install/bin/sbtenv-install
@@ -32,16 +32,23 @@ abs_dirname() {
   cd "${cwd}"
 }
 
-SHA1SUM=$(type -p sha1sum shasum | head -1)
-if [ -z "${SHA1SUM}" ]; then
-  echo "sbt-install: cannot find sha1sum - are you missing GNU coreutils?" >& 2
-  exit 1
-fi
-
 version=${1}
 recipe="$(abs_dirname ${0})/../share/${version}"
 if [ -f "${recipe}" ]; then
   source ${recipe}
+  if [ ! -z "${sha1sum_file}" ]; then
+    SHA1SUM=$(type -p sha1sum shasum | head -1)
+    if [ -z "${SHA1SUM}" ]; then
+      echo "sbt-install: cannot find 'sha1sum' or 'shasum' executable needed for verifying download integrity - are you missing GNU coreutils?" >& 2
+      exit 1
+    fi
+  elif [ ! -z "${signature_file}" ]; then
+    GPG=$(type -p gpg | head -1)
+    if [ -z "${GPG}" ]; then
+      echo "sbt-install: cannot find 'gpg' executable needed for verifying package signatures" >& 2
+      exit 1
+    fi
+  fi
   echo "Installing ${version}:"
   for (( i=0; i<${#sites[@]}; ++i))
   do
@@ -54,6 +61,14 @@ if [ -f "${recipe}" ]; then
       curl -#LO "${sites[$i]}/${sha1sum_file}"
       echo "Checking SHA-1 checksum..."
       echo "$(cat "${sha1sum_file}")  ${archive_file}" | ${SHA1SUM} --check -
+    elif [ ! -z "${signature_file}" ]; then
+      curl -#LO "${sites[$i]}/${signature_file}"
+      keyserver=""
+      if [ ! -z "${signature_keyserver}" ]; then
+        keyserver="--keyserver ${signature_keyserver}"
+      fi
+      echo "Checking GPG signature..."
+      ${GPG} --verify ${keyserver} "${signature_file}" "${archive_file}"
     fi
     if [ $? ]; then
       echo "Extracting files..."

--- a/plugins/sbt-install/share/sbt-1.0.0
+++ b/plugins/sbt-install/share/sbt-1.0.0
@@ -1,0 +1,6 @@
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v1.0.0"
+    );
+archive_file="sbt-1.0.0.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
This is a somewhat experimental addition of sbt-1.0.0 support. 

It seems that the sbt folks are using github releases as the official download link. Since they provide a GPG signature instead of a SHA1 hash, I added optional support for signature verification.

Adding the GPG dependency is not ideal, but it is only required if the 1.0.0 release is installed, which isn't available through any other channel right now, and is preferable to the alternative of not checking the signature at all.