### PR TITLE
Add support for sbt v1.2.4, v1.2.6, v1.2.7 and v0.13.18

### DIFF
--- a/plugins/sbt-install/share/sbt-0.13.18
+++ b/plugins/sbt-install/share/sbt-0.13.18
@@ -1,0 +1,7 @@
+version="0.13.18"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"

--- a/plugins/sbt-install/share/sbt-1.2.4
+++ b/plugins/sbt-install/share/sbt-1.2.4
@@ -1,0 +1,7 @@
+version="1.2.4"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"

--- a/plugins/sbt-install/share/sbt-1.2.6
+++ b/plugins/sbt-install/share/sbt-1.2.6
@@ -1,0 +1,7 @@
+version="1.2.6"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"

--- a/plugins/sbt-install/share/sbt-1.2.7
+++ b/plugins/sbt-install/share/sbt-1.2.7
@@ -1,0 +1,7 @@
+version="1.2.7"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
Add support for

 - [v1.2.4](https://github.com/sbt/sbt/releases/tag/v1.2.4)
 - [v1.2.6](https://github.com/sbt/sbt/releases/tag/v1.2.6)
 - [v1.2.7](https://github.com/sbt/sbt/releases/tag/v1.2.7)
 - [v0.13.18](https://github.com/sbt/sbt/releases/tag/v0.13.18)

