### PR TITLE
don't prefix sbtenv-version-project-read result with "sbt-"

### DIFF
--- a/libexec/sbtenv-version-project-read
+++ b/libexec/sbtenv-version-project-read
@@ -11,7 +11,7 @@ if [ -r "${VERSION_FILE}" ]; then
   version="${words[1]}"
 
   if [ -n "${version}" ]; then
-    echo "sbt-${version}"
+    echo ${version}
     exit
   fi
 fi


### PR DESCRIPTION
[sbtenv-version-name](https://github.com/sbtenv/sbtenv/blob/master/libexec/sbtenv-version-name#L30) generates a warning when the version has the "sbt-" prefix.