### PR TITLE
Add missing sbt versions

### DIFF
--- a/plugins/sbt-install/share/sbt-1.4.5
+++ b/plugins/sbt-install/share/sbt-1.4.5
@@ -1,0 +1,7 @@
+version="1.4.5"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"

--- a/plugins/sbt-install/share/sbt-1.4.6
+++ b/plugins/sbt-install/share/sbt-1.4.6
@@ -1,0 +1,7 @@
+version="1.4.6"
+sites=(
+    "https://github.com/sbt/sbt/releases/download/v${version}"
+    );
+archive_file="sbt-${version}.tgz"
+signature_file="${archive_file}.asc"
+signature_keyserver="hkp://keyserver.ubuntu.com:80"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.0
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.0.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.1
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.1.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.2
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.2
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.2.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.3
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.3
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.3.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.4
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.4
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.4.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.5
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.5
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.5.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.4.6
+++ b/plugins/sbt-install/share/sbt-dotty-v0.4.6
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.4.6.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.5.0
+++ b/plugins/sbt-install/share/sbt-dotty-v0.5.0
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.5.0.tar.gz"

--- a/plugins/sbt-install/share/sbt-dotty-v0.5.1
+++ b/plugins/sbt-install/share/sbt-dotty-v0.5.1
@@ -1,0 +1,4 @@
+sites=(
+    "https://github.com/lampepfl/dotty/archive"
+    );
+archive_file="sbt-dotty-v0.5.1.tar.gz"


### PR DESCRIPTION
Added the following:
- 1.4.5
- 1.4.6
- dotty-v0.4.0
- dotty-v0.4.1
- dotty-v0.4.2
- dotty-v0.4.3
- dotty-v0.4.4
- dotty-v0.4.5
- dotty-v0.4.6
- dotty-v0.5.0
- dotty-v0.5.1