### PR TITLE
Added SUPPRESS_EXTRANEOUS_PREFIX_WARNING environment variable

### DIFF
--- a/libexec/sbtenv-version-name
+++ b/libexec/sbtenv-version-name
@@ -27,7 +27,8 @@ version_exists() {
 if version_exists "${SBTENV_VERSION}"; then
   echo "${SBTENV_VERSION}"
 elif version_exists "${SBTENV_VERSION#sbt-}"; then
-  { echo "warning: ignoring extraneous \`sbt-\` prefix in version \`${SBTENV_VERSION}\`"
+  [[ -v SUPPRESS_EXTRANEOUS_PREFIX_WARNING ]] || {
+    echo "warning: ignoring extraneous \`sbt-\` prefix in version \`${SBTENV_VERSION}\`"
     echo "         (set by $(sbtenv-version-origin))"
   } >& 2
   echo "${SBTENV_VERSION#sbt-}"


### PR DESCRIPTION
If `SUPPRESS_EXTRANEOUS_PREFIX_WARNING` is set to `yes`, `true` or `1` (matched case-insensitive), the warning will be suppressed.

> The warning ought to be removed altogether, as a matter of bad UX, where it scolds the person (the user) who is powerless to fix it; this is really am issue between `SBT` and `sbtenv` vendors, not your average Scala dev.